### PR TITLE
Do case-insensitive search for "en-CA"

### DIFF
--- a/index.php
+++ b/index.php
@@ -108,7 +108,7 @@ function uw_waterloo_quest_schedule($input, $format, $summary = '@code @type in 
   //otherwise, no swap
   $swap = false;
   $locale = $_SERVER["HTTP_ACCEPT_LANGUAGE"];
-  if (strpos($locale, 'en-CA') !== FALSE){
+  if (stripos($locale, 'en-CA') !== FALSE){
     $swap = true;
   }
   //start the algorithm


### PR DESCRIPTION
Some browsers (iike mine, Pale Moon 25 on Linux) send the locale lowercase. With case-sensitive search, I end up with 1969 and 1970 for the years.
