### PR TITLE
Support for TPM 1X000

### DIFF
--- a/index.php
+++ b/index.php
@@ -132,7 +132,7 @@ function uw_waterloo_quest_schedule($input, $format, $summary = '@code @type in 
     
     $regex = '/
     (
-      (\w{2,5}\ \w{3,4})\ -\                        #code
+      (\w{2,5}\ \w{3,5})\ -\                        #code
       ([^\r\n]+)                                    #name
     )
     |


### PR DESCRIPTION
TPM 1X000 would break this because 1X000 is 5 characters and currently expected 3-4 characters instead. Current behaviour would place all TPM components under the last parsed course.